### PR TITLE
fix: add `make translation_requirements`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 clean_translations_temp_directory:
 	rm -rf I18N/
 
-create_virtual_env:
-	rm -rf .venv
-	python3 -m venv .venv
-	. .venv/bin/activate && pip install -r i18n_scripts/requirements.txt
+translation_requirements:
+	pip install -r i18n_scripts/requirements.txt
 
-pull_translations: clean_translations_temp_directory create_virtual_env
-	. .venv/bin/activate && atlas pull $(ATLAS_OPTIONS) translations/openedx-app-ios/I18N:I18N
-	. .venv/bin/activate && python i18n_scripts/translation.py --split
+pull_translations: clean_translations_temp_directory
+	atlas pull $(ATLAS_OPTIONS) translations/openedx-app-ios/I18N:I18N
+	python i18n_scripts/translation.py --split
 
-extract_translations: clean_translations_temp_directory create_virtual_env
-	. .venv/bin/activate && python i18n_scripts/translation.py --combine
+extract_translations: clean_translations_temp_directory
+	python i18n_scripts/translation.py --combine

--- a/i18n_scripts/requirements.txt
+++ b/i18n_scripts/requirements.txt
@@ -1,4 +1,4 @@
-# Package dependencies
+# Translation processing dependencies
 openedx-atlas==0.6.0
-# TODO: Publish new version on pypi as `python3-localizable`
+# TODO: Publish new version on pypi as `python3-localizable` https://github.com/chrisballinger/python-localizable/pull/4
 git+https://github.com/Amr-Nash/python-localizable.git@15d3bf2466d0de1a826d3f0ff1f365b0c1910f56

--- a/i18n_scripts/translation.py
+++ b/i18n_scripts/translation.py
@@ -122,7 +122,7 @@ def combine_translation_files(modules_dir=None):
     Combine translation files from different modules into a single file.
     """
     if not modules_dir:
-        modules_dir = os.path.dirname(os.path.dirname(__file__))
+        modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     combined_translation_dict = get_translations(modules_dir)
     write_combined_translation_file(modules_dir, combined_translation_dict)
 


### PR DESCRIPTION
### Changes

 - Refactored translations so it becomes compatible with https://github.com/openedx/openedx-translations/pull/6068
 - Removed the automated `create_virtual_env` in favor of a manual one to account for different virtual env installations
 - Added `make translation_requirements` to make it easier for GitHub Actions integration: https://github.com/openedx/openedx-translations/pull/6068
 - Fixed a bug in path in GitHub Actions
 - Removed `clean_translations_temp_directory` after `pull_translations`